### PR TITLE
Harden boot chain: don't let a failed code-update block the pipeline

### DIFF
--- a/deploy/services/video-pipeline.service
+++ b/deploy/services/video-pipeline.service
@@ -1,8 +1,10 @@
 [Unit]
 Description=Richmond Sunlight Video Processing Pipeline
+# Order after the code-update service, but only Wants= (not Requires=): a
+# best-effort code update must never be a hard gate that blocks an already-
+# deployed pipeline. If update-from-s3.service fails, systemd still runs us.
 After=network-online.target update-from-s3.service
-Wants=network-online.target
-Requires=update-from-s3.service
+Wants=network-online.target update-from-s3.service
 ConditionPathExists=/home/ubuntu/video-processor.txt
 
 [Service]

--- a/deploy/update-from-s3.sh
+++ b/deploy/update-from-s3.sh
@@ -76,16 +76,21 @@ find "$APP_DIR" -type f -name '*.sh' -print0 | xargs -0 chmod +x
 echo "Installing Composer dependencies..."
 composer install --no-interaction --prefer-dist --no-dev --optimize-autoloader
 
-# Save the ETag so we know what version we're running
-echo "$REMOTE_ETAG" > "$ETAG_FILE"
-
 # Run the deploy script if it exists (for any post-update configuration)
 if [[ -x "${APP_DIR}/deploy/deploy.sh" ]]; then
   echo "Running deploy script..."
   "${APP_DIR}/deploy/deploy.sh"
 fi
 
+# Save the ETag only after a fully successful update (including deploy.sh), so a
+# failed deploy retries on the next boot instead of being masked as "already
+# latest". The ETag write used to sit before deploy.sh, silently hiding deploy
+# failures — the box would report "no update needed" while never finishing one.
+echo "$REMOTE_ETAG" > "$ETAG_FILE"
+
 echo "Update complete (now running: ${REMOTE_ETAG})."
+# Best-effort logging only — a failed Log write (DB/Slack down) must not fail the
+# unit and, under the old Requires=, block the pipeline from ever starting.
 if command -v php >/dev/null 2>&1; then
-  php -r "require '${APP_DIR}/includes/settings.inc.php'; require '${APP_DIR}/includes/class.Log.php'; (new Log())->put('Update complete (now running: ${REMOTE_ETAG}).', 3);"
+  php -r "require '${APP_DIR}/includes/settings.inc.php'; require '${APP_DIR}/includes/class.Log.php'; (new Log())->put('Update complete (now running: ${REMOTE_ETAG}).', 3);" || true
 fi


### PR DESCRIPTION
- video-pipeline.service: Requires= -> Wants= on update-from-s3.service (keep After= ordering). A best-effort code update must not be a hard gate that bricks an already-deployed pipeline; a failed update now degrades to 'run the code already on disk' instead of 'do nothing'.
- update-from-s3.sh: write the ETag only after deploy.sh succeeds (was written before it), so a failed deploy retries next boot instead of being masked as 'already latest'; and make the closing Log::put best-effort (|| true) so a DB/Slack hiccup can't fail the update unit.